### PR TITLE
feat(scheduler): add runner, tests, and docs

### DIFF
--- a/agents/scheduler.py
+++ b/agents/scheduler.py
@@ -1,0 +1,140 @@
+"""Simple in-process scheduler for periodic jobs (PoC).
+
+Provides a tiny job registry and a background runner that executes registered
+callables at a fixed interval. This is intentionally lightweight and suitable
+for local demos or as a foundation for wiring APScheduler/cron later.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Callable, Dict
+
+
+@dataclass
+class Job:
+    name: str
+    func: Callable[[], None]
+    interval_seconds: int
+    last_run: float = field(default=0.0)
+
+
+_JOBS: Dict[str, Job] = {}
+
+_runner_thread: threading.Thread | None = None
+_stop_event: threading.Event | None = None
+
+
+def register_job(name: str, func: Callable[[], None], interval_seconds: int) -> None:
+    """Register a job to run approximately every `interval_seconds`.
+
+    If a job with the same name exists it will be replaced.
+    """
+    _JOBS[name] = Job(name=name, func=func, interval_seconds=interval_seconds)
+
+
+def unregister_job(name: str) -> None:
+    _JOBS.pop(name, None)
+
+
+def list_jobs() -> dict:
+    return {n: (j.interval_seconds, j.last_run) for n, j in _JOBS.items()}
+
+
+def _job_runner(poll_interval: float = 1.0) -> None:
+    global _stop_event
+    while not _stop_event.is_set():
+        now = time.time()
+        for job in list(_JOBS.values()):
+            try:
+                if now - job.last_run >= job.interval_seconds:
+                    job.last_run = now
+                    threading.Thread(target=_run_job_safe, args=(job,)).start()
+            except Exception:
+                # never let one job crash the loop
+                print(f"Error scheduling job {job.name}")
+        _stop_event.wait(poll_interval)
+
+
+def _run_job_safe(job: Job) -> None:
+    try:
+        print(f"[{datetime.utcnow().isoformat()}] Running job: {job.name}")
+        job.func()
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Job {job.name} failed: {exc}")
+
+
+def start(poll_interval: float = 1.0) -> None:
+    """Start the scheduler background thread."""
+    global _runner_thread, _stop_event
+    if _runner_thread and _runner_thread.is_alive():
+        return
+    _stop_event = threading.Event()
+    _runner_thread = threading.Thread(target=_job_runner, args=(poll_interval,), daemon=True)
+    _runner_thread.start()
+
+
+def stop() -> None:
+    """Stop the scheduler background thread and wait for it to finish."""
+    global _runner_thread, _stop_event
+    if _stop_event:
+        _stop_event.set()
+    if _runner_thread:
+        _runner_thread.join(timeout=5.0)
+    _runner_thread = None
+    _stop_event = None
+
+
+def run_once() -> None:
+    """Run each registered job once (synchronously)."""
+    for job in list(_JOBS.values()):
+        _run_job_safe(job)
+
+
+def register_default_jobs() -> None:
+    """Register a couple of PoC jobs: scrape all sources and generate an agenda.
+
+    Jobs are registered but not started automatically. Users should call
+    `start()` to run the background scheduler.
+    """
+    # Import inside function to avoid heavy imports at module import time
+    try:  # pragma: no cover - integration glue
+        from ingest.scrapers.scraper_registry import list_sources
+        from ingest.scrapers import EventScraper, JobScraper, PartnerScraper
+        from ingest.scrapers.integrate import integrate_scraped_item
+        from agents.skills.president import generate_agenda_with_llm
+        from ingest.storage import store_conversion
+        from datetime import date
+
+        def _scrape_all() -> None:
+            sources = list_sources()
+            parser_map = {
+                "event": EventScraper,
+                "job": JobScraper,
+                "partner": PartnerScraper,
+            }
+            for s in sources:
+                parser = s.get("parser")
+                cls = parser_map.get(parser)
+                if not cls:
+                    print(f"No parser for {parser} (source {s.get('id')})")
+                    continue
+                try:
+                    scr = cls(rate_limit_seconds=0, respect_robots=False)
+                    item = scr.scrape(s.get("url"), s.get("selectors", {}))
+                    integrate_scraped_item(item, s.get("id"))
+                except Exception as e:  # pragma: no cover - runtime integration
+                    print(f"Error scraping {s.get('id')}: {e}")
+
+        def _generate_agenda() -> None:
+            notes = {"title": "Scheduled Agenda", "date": str(date.today()), "summary": "Auto-generated agenda."}
+            md = generate_agenda_with_llm(notes)
+            store_conversion(md, {"source": "scheduler"}, {}, "agenda_scheduled", "out")
+
+        register_job("scrape_all_sources", _scrape_all, interval_seconds=60 * 60 * 24)
+        register_job("generate_weekly_agenda", _generate_agenda, interval_seconds=60 * 60 * 24 * 7)
+    except Exception:  # pragma: no cover - best-effort registration
+        # If dependencies aren't available (tests, import-time), skip registration
+        print("Skipping default job registration (dependencies missing)")

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,75 @@
+Scheduler — running the project's scheduler under system services
+===============================================================
+
+This file provides example configurations for running the project's scheduler
+either as a systemd service (Linux) or as a Windows Scheduled Task. The
+scheduler is intentionally lightweight and suitable for demos; for production
+use consider APScheduler, Celery, or external job platforms.
+
+Files used by examples
+- `scripts/run_scheduler.py` — small runner that registers default jobs and
+  starts the scheduler loop (or runs jobs once with `--once`).
+
+Systemd example
+---------------
+
+1. Create a system user (optional):
+
+   sudo useradd --system --no-create-home nonprofit
+
+2. Create a systemd service file `/etc/systemd/system/nonprofit-scheduler.service`:
+
+```
+[Unit]
+Description=Nonprofit Tool Scheduler
+After=network.target
+
+[Service]
+Type=simple
+User=nonprofit
+WorkingDirectory=/path/to/your/repo
+Environment=PYTHONPATH=/path/to/your/repo
+ExecStart=/path/to/venv/bin/python scripts/run_scheduler.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+3. Reload systemd and enable the service:
+
+```
+sudo systemctl daemon-reload
+sudo systemctl enable --now nonprofit-scheduler.service
+sudo journalctl -u nonprofit-scheduler.service -f
+```
+
+Windows Scheduled Task example (PowerShell)
+------------------------------------------
+
+1. Open an elevated PowerShell prompt and create a scheduled task that runs
+   the scheduler at startup and keeps it running.
+
+2. Example using `Register-ScheduledTask` with an Action that starts Python
+   in a virtual environment and runs the `scripts/run_scheduler.py` script:
+
+```powershell
+$action = New-ScheduledTaskAction -Execute 'C:\path\to\venv\Scripts\python.exe' -Argument 'C:\path\to\repo\scripts\run_scheduler.py'
+$trigger = New-ScheduledTaskTrigger -AtStartup
+$principal = New-ScheduledTaskPrincipal -UserId "NT AUTHORITY\SYSTEM" -RunLevel Highest
+Register-ScheduledTask -TaskName "NonprofitToolScheduler" -Action $action -Trigger $trigger -Principal $principal
+
+# To start immediately:
+Start-ScheduledTask -TaskName "NonprofitToolScheduler"
+# To view logs: use Event Viewer -> Applications and Services Logs, or
+# capture stdout/stderr to a file by wrapping the command in a launcher script.
+```
+
+Notes and recommendations
+-------------------------
+- When running under a system scheduler, prefer absolute paths for `WorkingDirectory`
+  and the Python executable.
+- Keep secrets and credentials out of the repository; use OS-level secret stores
+  or environment variables provided by the host.
+- For long-running or production workloads, replace the in-process scheduler
+  with a more robust job runner and add monitoring/alerting.

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -1,0 +1,46 @@
+"""Run the in-process scheduler for demos or system scheduling.
+
+Usage examples:
+  - Run once (execute registered jobs synchronously):
+      PYTHONPATH=. python scripts/run_scheduler.py --once
+
+  - Start background scheduler (runs until interrupted):
+      PYTHONPATH=. python scripts/run_scheduler.py
+
+This script registers the default PoC jobs (if available) and starts the
+scheduler. It is intentionally minimal so it can be invoked by system schedulers
+or used locally for testing.
+"""
+from __future__ import annotations
+
+import argparse
+import time
+
+from agents import scheduler
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the project's scheduler")
+    parser.add_argument("--once", action="store_true", help="Run each job once and exit")
+    args = parser.parse_args()
+
+    # register PoC jobs if available
+    scheduler.register_default_jobs()
+
+    if args.once:
+        scheduler.run_once()
+        return 0
+
+    try:
+        scheduler.start()
+        print("Scheduler started. Press Ctrl+C to stop.")
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Stopping scheduler...")
+        scheduler.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,22 @@
+import time
+
+from agents import scheduler
+
+
+def test_register_and_run_once():
+    called = []
+
+    def _job():
+        called.append("ok")
+
+    scheduler.register_job("test_job", _job, interval_seconds=1)
+    # run_once should synchronously execute registered jobs
+    scheduler.run_once()
+    assert called == ["ok"]
+
+
+def test_list_jobs_contains_registered():
+    # ensure list_jobs reflects registration
+    scheduler.register_job("xx", lambda: None, interval_seconds=5)
+    lj = scheduler.list_jobs()
+    assert "xx" in lj


### PR DESCRIPTION
Adds an in-process scheduler module (), a runnable starter script (), unit tests (), and scheduler docs (). Default PoC jobs (scrape + agenda generation) are registered but scheduler must be started explicitly.\n\nChecklist:\n- [x] Tests added for scheduler behavior\n- [x] Docs added/updated (docs/scheduler.md)\n- [ ] Manual verification: start/stop/run-once\n\nNotes: branch: feat/scheduler-pr